### PR TITLE
Notmalize String based on given char.

### DIFF
--- a/src/normalize_string/normalize_string.cpp
+++ b/src/normalize_string/normalize_string.cpp
@@ -1,0 +1,62 @@
+/*
+ * normalize_string.cpp
+ *
+ *  Created on: Nov 15, 2014
+ *      Author: edwardh
+ */
+
+#include "string.h"
+#include "normalize_string.h"
+
+
+unsigned int Normalizer::normalize_string_inplace(char * string, size_t& string_len, const char norm_char)
+{
+    size_t normalized_string_len = string_len;
+
+    for(char *str_itr = string; str_itr < &string[normalized_string_len-1]; ++str_itr)
+    {
+        if(norm_char == *str_itr)
+        {
+            char *dst;
+            for(dst = ++str_itr; (norm_char == *str_itr); ++str_itr);
+
+            if(str_itr > dst)
+            {
+                memmove(dst, str_itr, normalized_string_len - (str_itr - string));
+                normalized_string_len -= str_itr - dst;
+            }
+        }
+    }
+
+    int num_of_reduced_appearances = string_len - normalized_string_len;
+    string_len = normalized_string_len;
+
+    return num_of_reduced_appearances;
+}
+
+
+
+unsigned int Normalizer::normalize_string_fast(const char *src_string, char *dst_string, size_t& string_len, const char norm_char)
+{
+    const char  *in_itr = src_string;
+    char        *out_itr = dst_string;
+
+    while(in_itr < &src_string[string_len-1])
+    {
+        *out_itr = *in_itr;
+
+        if(norm_char == *in_itr)
+            for(++in_itr; (norm_char == *in_itr); ++in_itr);
+        else
+            ++in_itr;
+
+        ++out_itr;
+    }
+
+    string_len = out_itr - dst_string;
+    size_t src_string_len             = in_itr - src_string;
+    size_t num_of_reduced_appearances = src_string_len - string_len;
+
+    return num_of_reduced_appearances;
+}
+

--- a/src/normalize_string/normalize_string.h
+++ b/src/normalize_string/normalize_string.h
@@ -1,0 +1,34 @@
+/*
+ * normalize_string.h
+ *
+ * Description:
+ * given a string and a char, normalize the string
+ * by removing consecutive appearances of the char,
+ * outputting a new string.
+ *
+ * Two implementation are given:
+ * - Inplace, which does not require additional memory.
+ * - Fast, which process the input at O(n) but requires an additional memory (O(n)).
+ *
+ * Both implementations output 3 results:
+ * - Normalized string.
+ * - Updated string length.
+ * - The number of characters removed.
+ *
+ *  Created on: Nov 15, 2014
+ *      Author: edwardh
+ */
+
+#ifndef NORMALIZE_STRING_H_
+#define NORMALIZE_STRING_H_
+
+
+class Normalizer
+{
+public:
+    static unsigned int normalize_string_inplace(char * string, size_t& string_len, const char norm_char);
+    static unsigned int normalize_string_fast(const char *src_string, char *dst_string, size_t& string_len, const char norm_char);
+};
+
+
+#endif /* NORMALIZE_STRING_H_ */

--- a/unit_tester/build/mk_common/utest_config_production_path.mk
+++ b/unit_tester/build/mk_common/utest_config_production_path.mk
@@ -4,7 +4,8 @@
 
 #	When all source files in a folder are under tests, it is prefered to add the folder instead of adding individual source files.
 SRC_DIRS = \
-	$(PRODUCTION_SOURCES)/llist
+	$(PRODUCTION_SOURCES)/llist\
+	$(PRODUCTION_SOURCES)/normalize_string\
 #	<Add here the folders that contain code under test>
 
 SRC_FILES = \
@@ -12,5 +13,6 @@ SRC_FILES = \
 #	<Add here the source file that is being tested>
 
 INCLUDE_DIRS +=\
-	$(PRODUCTION_SOURCES)/
+	$(PRODUCTION_SOURCES)/\
+	$(PRODUCTION_SOURCES)/normalize_string\
 #	<Add here the folder that contains the headers. Note that the order is important!>

--- a/unit_tester/build/mk_common/utest_config_test_path.mk
+++ b/unit_tester/build/mk_common/utest_config_test_path.mk
@@ -13,6 +13,7 @@ TEST_SRC_DIRS = \
 	$(TEST_ROOT)/helpers/src\
 	$(TEST_ROOT)/tests\
 	$(TEST_ROOT)/tests/llist_test\
+	$(TEST_ROOT)/tests/normalize_string_test\
 #	<Add here the folder that contains the tester source>	
 
 MOCKS_SRC_DIRS =\

--- a/unit_tester/tests/normalize_string_test/normalize_string_test.cpp
+++ b/unit_tester/tests/normalize_string_test/normalize_string_test.cpp
@@ -1,0 +1,155 @@
+/*
+ * normalize_string_test.cpp
+ *
+ *  Created on: Nov 15, 2014
+ *      Author: edwardh
+ */
+
+
+
+#include "CppUTest/TestHarness.h"
+
+#include "normalize_string.h"
+
+
+TEST_GROUP(inline_normalize_string)
+{
+    void setup() {}
+
+    void teardown() {}
+};
+
+TEST(inline_normalize_string, nothing_to_normalize)
+{
+    const char   in_string[]       = "nothing_to_normalize";
+    const char   expected_string[] = "nothing_to_normalize";
+    size_t       string_len = sizeof(in_string);
+    const char   normalize_char = '@';
+
+    char        *result_string = (char*)in_string;
+    unsigned int num_of_reduced_appearances;
+
+    num_of_reduced_appearances = Normalizer::normalize_string_inplace((char*)in_string, string_len, normalize_char);
+    LONGS_EQUAL(0, num_of_reduced_appearances);
+    STRCMP_EQUAL(expected_string, result_string);
+}
+
+TEST(inline_normalize_string, normalize_uri)
+{
+    const char   in_string[]        = "http://someuri//that_we///wouldlike/to/normalize";
+    const char   expected_string[]  = "http:/someuri/that_we/wouldlike/to/normalize";
+    size_t       string_len = sizeof(in_string);
+    const char   normalize_char = '/';
+
+    char        *result_string = (char*)in_string;
+    unsigned int num_of_reduced_appearances;
+
+    num_of_reduced_appearances = Normalizer::normalize_string_inplace((char*)in_string, string_len, normalize_char);
+
+    LONGS_EQUAL(4, num_of_reduced_appearances);
+    STRCMP_EQUAL(expected_string, result_string);
+}
+
+TEST(inline_normalize_string, normalize_string_to_a_single_char)
+{
+    const char   in_string[]        = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+    const char   expected_string[]  = "a";
+    size_t       string_len = sizeof(in_string);
+    const char   normalize_char = 'a';
+    const int    expected_reduced_chars = string_len - 2; // original string size, minus the EOS and the single char left.
+
+    char        *result_string = (char*)in_string;
+    unsigned int num_of_reduced_appearances;
+
+    num_of_reduced_appearances = Normalizer::normalize_string_inplace((char*)in_string, string_len, normalize_char);
+
+    LONGS_EQUAL(expected_reduced_chars, num_of_reduced_appearances);
+    STRCMP_EQUAL(expected_string, result_string);
+}
+
+TEST(inline_normalize_string, normalize_zero_string)
+{
+    const char   in_string[]        = "";
+    const char   expected_string[]  = "";
+    size_t       string_len = sizeof(in_string);
+    const char   normalize_char = 'a';
+
+    char        *result_string = (char*)in_string;
+    unsigned int num_of_reduced_appearances;
+
+    num_of_reduced_appearances = Normalizer::normalize_string_inplace((char*)in_string, string_len, normalize_char);
+
+    LONGS_EQUAL(0, num_of_reduced_appearances);
+    STRCMP_EQUAL(expected_string, result_string);
+}
+
+TEST_GROUP(fast_normalize_string)
+{
+    void setup() {}
+
+    void teardown() {}
+};
+
+TEST(fast_normalize_string, nothing_to_normalize)
+{
+    const char   in_string[]       = "nothing_to_normalize";
+    const char   expected_string[] = "nothing_to_normalize";
+    size_t       string_len = sizeof(in_string);
+    char         out_string[sizeof(in_string)] = "";
+    const char   normalize_char = '@';
+
+    unsigned int num_of_reduced_appearances;
+
+    num_of_reduced_appearances = Normalizer::normalize_string_fast(in_string, out_string, string_len, normalize_char);
+    LONGS_EQUAL(0, num_of_reduced_appearances);
+    STRCMP_EQUAL(expected_string, out_string);
+}
+
+TEST(fast_normalize_string, normalize_uri)
+{
+    const char   in_string[]        = "http://someuri//that_we///wouldlike/to/normalize";
+    const char   expected_string[]  = "http:/someuri/that_we/wouldlike/to/normalize";
+    size_t       string_len = sizeof(in_string);
+    char         out_string[sizeof(in_string)] = "";
+    const char   normalize_char = '/';
+
+    unsigned int num_of_reduced_appearances;
+
+    num_of_reduced_appearances = Normalizer::normalize_string_fast(in_string, out_string, string_len, normalize_char);
+
+    LONGS_EQUAL(4, num_of_reduced_appearances);
+    STRCMP_EQUAL(expected_string, out_string);
+}
+
+TEST(fast_normalize_string, normalize_string_to_a_single_char)
+{
+    const char   in_string[]        = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+    const char   expected_string[]  = "a";
+    size_t       string_len = sizeof(in_string);
+    char         out_string[sizeof(in_string)] = "";
+    const char   normalize_char = 'a';
+    const int    expected_reduced_chars = string_len - 2; // original string size, minus the EOS and the single char left.
+
+    unsigned int num_of_reduced_appearances;
+
+    num_of_reduced_appearances = Normalizer::normalize_string_fast(in_string, out_string, string_len, normalize_char);
+
+    LONGS_EQUAL(expected_reduced_chars, num_of_reduced_appearances);
+    STRCMP_EQUAL(expected_string, out_string);
+}
+
+TEST(fast_normalize_string, normalize_zero_string)
+{
+    const char   in_string[]        = "";
+    const char   expected_string[]  = "";
+    size_t       string_len = sizeof(in_string);
+    char         out_string[8] = "";
+    const char   normalize_char = 'a';
+
+    unsigned int num_of_reduced_appearances;
+
+    num_of_reduced_appearances = Normalizer::normalize_string_fast(in_string, out_string, string_len, normalize_char);
+
+    LONGS_EQUAL(0, num_of_reduced_appearances);
+    STRCMP_EQUAL(expected_string, out_string);
+}


### PR DESCRIPTION
Given a string and a char, normalize the string
by removing consecutive appearances of the char,
outputting a new string.
Two implementation are given:
- Inplace, which does not require additional memory.
- Fast, which process the input at O(n) but requires an additional memory (O(n)).

Both implementations output 3 results:
- Normalized string.
- Updated string length.
- The number of characters removed.